### PR TITLE
Enable per-game leaderboards

### DIFF
--- a/fruit-fusion.html
+++ b/fruit-fusion.html
@@ -1196,7 +1196,7 @@
             leaderboard = await ScoreManager.load(GAME_KEY);
         }
         async function addScoreToLeaderboard(initials, newScore) {
-            await ScoreManager.add(GAME_KEY, initials, newScore);
+            leaderboard = await ScoreManager.add(GAME_KEY, initials, newScore);
         }
         async function displayLeaderboard() {
             await loadLeaderboard();

--- a/tap-blitz.html
+++ b/tap-blitz.html
@@ -764,7 +764,7 @@
         });
         submitInitialsButton.addEventListener('click', async () => {
             const initials = initialsInput.value.trim().toUpperCase();
-            if (/^[A-Z]{1,3}$/.test(initials)) {
+            if (/^[A-Z]{3}$/.test(initials)) {
                 await saveHighScore(initials);
                 initialsPrompt.style.display = 'none';
                 gameMessage.textContent = `Game Over! Final Score: ${score}. Saved!`;
@@ -773,7 +773,7 @@
                 playAgainButton.style.display = 'block';
                 playSound('gameOver');
             } else {
-                alert('Please enter 1-3 letters (A-Z).');
+                alert('Please enter exactly 3 letters (A-Z).');
                 initialsInput.focus();
             }
         });

--- a/tetris.html
+++ b/tetris.html
@@ -661,11 +661,12 @@
         }
         submitInitialsBtn.addEventListener('click', async () => {
             let initials = initialsInput.value.trim().toUpperCase();
-            if (initials.length > 0 && initials.length <= 3 && /^[A-Z]+$/.test(initials)) {
-                await saveHighScore(initials, score); initialsPrompt.style.display = 'none';
+            if (/^[A-Z]{3}$/.test(initials)) {
+                await saveHighScore(initials, score);
+                initialsPrompt.style.display = 'none';
                 showMessage("Game Over! Score: " + score + ". Saved!", "Play Again", resetGame);
             } else {
-                showMessage("Please enter 1-3 uppercase letters for initials.", "OK", () => {
+                showMessage("Please enter exactly 3 uppercase letters.", "OK", () => {
                     hideMessage(); initialsPrompt.style.display = 'block'; initialsInput.focus();
                 });
             }


### PR DESCRIPTION
## Summary
- maintain separate leaderboard storage per game
- refresh leaderboard data after scoring in Fruit Fusion
- require exactly 3 letters for initials in Tetris and Tap Blitz

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845be539e80833093476baa6ce5129b