### PR TITLE
Fix Fruit Fusion scoring

### DIFF
--- a/fruit-fusion.html
+++ b/fruit-fusion.html
@@ -984,14 +984,17 @@
             }
         }
 
+        // Award points for merges based on the size of the fused fruit.
+        // The resulting fruit's points act as the base score with a small
+        // bonus from the size of the fruit being merged.
         function calculateMergeScore(baseFruit, resultingFruit) {
-            const sizeFactor = (baseFruit.radius + resultingFruit.radius) / BASE_FRUITS_DATA_STRUCTURE[0].radius;
-            return Math.round(sizeFactor + (resultingFruit.points || 0));
+            return (resultingFruit.points || 0) + Math.round((baseFruit.points || 0) / 2);
         }
 
+        // When the final (largest) fruits fuse and pop, give a big reward but
+        // keep it in a reasonable range.
         function calculatePopScore(fruit) {
-            const sizeFactor = fruit.radius / BASE_FRUITS_DATA_STRUCTURE[0].radius;
-            return Math.round(sizeFactor * (fruit.points || 0));
+            return Math.round((fruit.points || 0) * 4);
         }
         
         function handleCollision(event) {


### PR DESCRIPTION
## Summary
- give points for merging based on fruit size
- add bigger reward for popping the largest fruit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847afe02aa48330bc43859722b04388