### PR TITLE
Add Switch Online catalog website

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
           <ul>
             <li><a href="websites/whales">Whale Wonders</a></li>
             <li><a href="websites/human-body">Discover the Human Body</a></li>
+            <li><a href="websites/switch-catalog">Switch Online Catalog</a></li>
           </ul>
       </div>
     </div>

--- a/websites/switch-catalog/index.html
+++ b/websites/switch-catalog/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Switch Online Catalog</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <h1>Switch Online Catalog</h1>
+    <nav>
+      <a href="#nes">NES</a>
+      <a href="#snes">SNES</a>
+      <a href="#n64">Nintendo 64</a>
+      <a href="#gb">Game Boy</a>
+      <a href="#gba">GBA</a>
+      <a href="#genesis">Genesis</a>
+    </nav>
+  </header>
+  <main>
+    <section id="nes">
+      <h2>NES Classics</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>Super Mario Bros. 3 (1988)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Bros. Wonder's clever levels</p>
+          <p>Mario and Luigi hop through eight themed worlds brimming with secrets and suit power-ups.</p>
+          <p>Bowser kidnaps the Kings; the brothers reclaim each kingdom to rescue Princess Peach.</p>
+          <p>The game showcased the NES at its peak with world maps and varied play styles.</p>
+          <p>Tight controls and save states make revisiting levels a breezy challenge.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid (1986)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> Metroid Dread's labyrinthine maps</p>
+          <p>Samus explores Planet Zebes, acquiring upgrades to infiltrate Mother Brain's lair.</p>
+          <p>The mission is sparse on text but steeped in eerie isolation.</p>
+          <p>Metroid pioneered non-linear exploration and atmosphere on the NES.</p>
+          <p>Modern rewind features tame the original's high difficulty.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="snes">
+      <h2>Super NES Essentials</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>The Legend of Zelda: A Link to the Past (1991)</summary>
+          <p class="genre">Top-down Action-Adventure</p>
+          <p><strong>If you liked:</strong> Tears of the Kingdom’s shrine brainteasers</p>
+          <p>A sprawling 2-D Hyrule packed with secret-stuffed dungeons and gadget-driven puzzles.</p>
+          <p>Link collects three pendants, then rescues the seven Maidens to seal Ganon in the Dark World.</p>
+          <p>First Zelda to add a parallel world; R&D4 pioneered light/dark map layering on the SNES.</p>
+          <p>Snappy sword swings and unlimited save states keep difficulty fair while rewarding exploration.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario World (1990)</summary>
+          <p class="genre">2-D Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Bros. Wonder’s feel-good hopping</p>
+          <p>Caped Mario glides through 96 exits across Dinosaur Land. Most levels clock in under five minutes.</p>
+          <p>Bowser kidnaps Peach and Yoshi’s buddies; Mario frees them one zone at a time.</p>
+          <p>Launch title that sold over 20M copies, proving SNES’s Mode 7 and color depth.</p>
+          <p>Tight controls make even quick sessions satisfying—just chase one secret exit and bail.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="n64">
+      <h2>Nintendo 64 Favorites</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>Super Mario 64 (1996)</summary>
+          <p class="genre">3-D Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Odyssey’s open-ended playgrounds</p>
+          <p>Mario leaps through paintings in Peach’s Castle, tackling missions in sprawling courses.</p>
+          <p>The barebones story sets up a hunt for 120 Power Stars to oust Bowser.</p>
+          <p>Defined free-roaming 3D platforming and showcased analog control on N64.</p>
+          <p>The camera can be clunky, but save states help master tough stars.</p>
+        </details>
+        <details class="game-card">
+          <summary>The Legend of Zelda: Ocarina of Time (1998)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> Breath of the Wild’s sprawling quest</p>
+          <p>Young Link travels through time to thwart Ganondorf, exploring dungeons with puzzle-filled rooms.</p>
+          <p>The classic tale sees Link awaken as the Hero of Time to seal away evil.</p>
+          <p>Considered a landmark for 3D adventure design, influencing countless games.</p>
+          <p>Modern features reduce frustration from some obtuse moments.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="gb">
+      <h2>Game Boy Gems</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>The Legend of Zelda: Link's Awakening (1993)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> The handheld feel of Link Between Worlds</p>
+          <p>Link washes ashore on Koholint Island and must awaken the Wind Fish to escape.</p>
+          <p>The dreamlike narrative includes quirky cameos and mini-games.</p>
+          <p>One of the most ambitious Game Boy titles, pushing the hardware’s limits.</p>
+          <p>D-pad movement is a bit stiff, but quick-save lets you explore at your own pace.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid II: Return of Samus (1991)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> Metroid Dread’s relentless hunt</p>
+          <p>Samus lands on SR388 to eradicate the Metroid species, delving deeper into caverns.</p>
+          <p>Story is minimal but sets up the events of Super Metroid.</p>
+          <p>Introduced new abilities and a save feature uncommon for Game Boy games.</p>
+          <p>Monochrome graphics are simple, yet the exploration loop still shines.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="gba">
+      <h2>Game Boy Advance Highlights</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>Metroid Fusion (2002)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> Metroid Dread’s guided storytelling</p>
+          <p>Samus battles a deadly parasite while receiving mission briefs from her ship’s AI.</p>
+          <p>The tense story drives exploration through a space station overrun with mutants.</p>
+          <p>Praised for tight pacing and atmospheric graphics on the GBA.</p>
+          <p>Plentiful save rooms keep the suspense from becoming punishing.</p>
+        </details>
+        <details class="game-card">
+          <summary>Advance Wars (2001)</summary>
+          <p class="genre">Turn-Based Strategy</p>
+          <p><strong>If you liked:</strong> Fire Emblem Engage’s bite-size battles</p>
+          <p>Command armies across grid-based maps, capturing cities to fund new units.</p>
+          <p>The lighthearted campaign introduces different commanders with unique powers.</p>
+          <p>Helped popularize strategy games on handhelds with simple, deep mechanics.</p>
+          <p>Difficulty scales smoothly, and turns can be undone thanks to rewind.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="genesis">
+      <h2>Sega Genesis Picks</h2>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>Sonic the Hedgehog 2 (1992)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Sonic Mania’s speedy stages</p>
+          <p>Sonic and Tails dash through colorful zones collecting rings to stop Dr. Robotnik.</p>
+          <p>The simple story pushes you from zone to zone until the final showdown.</p>
+          <p>Introduced the spin dash and became one of the best-selling Genesis games.</p>
+          <p>Fast physics remain exhilarating, and save states ease the later levels.</p>
+        </details>
+        <details class="game-card">
+          <summary>Gunstar Heroes (1993)</summary>
+          <p class="genre">Run-and-Gun</p>
+          <p><strong>If you liked:</strong> Cuphead’s intense boss fights</p>
+          <p>Take on swarms of enemies with mix-and-match weapons in explosive stages.</p>
+          <p>The loose plot is an excuse for nonstop action.</p>
+          <p>Treasure’s debut title pushed the Genesis hardware with flashy effects.</p>
+          <p>Two-player co-op and constant action keep the fun factor high.</p>
+        </details>
+      </div>
+    </section>
+  </main>
+  <button id="toTop">&#8679;</button>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/websites/switch-catalog/script.js
+++ b/websites/switch-catalog/script.js
@@ -1,0 +1,8 @@
+const toTop = document.getElementById('toTop');
+window.addEventListener('scroll', () => {
+  if (window.scrollY > 300) toTop.style.display = 'flex';
+  else toTop.style.display = 'none';
+});
+toTop?.addEventListener('click', () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+});

--- a/websites/switch-catalog/style.css
+++ b/websites/switch-catalog/style.css
@@ -1,0 +1,77 @@
+:root {
+  --bg: #f8f8f8;
+  --text: #222;
+  --accent: #cc0000;
+  --card-bg: #fff;
+}
+
+body {
+  font-family: 'Inter', Arial, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+header {
+  background: var(--accent);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 0.5rem;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+main {
+  max-width: 900px;
+  margin: auto;
+  padding: 1rem;
+}
+
+section {
+  margin-top: 2rem;
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.game-card {
+  background: var(--card-bg);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.game-card summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.genre {
+  color: var(--accent);
+  font-style: italic;
+}
+
+#toTop {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add new `switch-catalog` informational site with sections for NES, SNES, N64, Game Boy, GBA and Genesis
- include sample game blurbs
- link the new site from the main menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ed6664b4483309bce45181c4931d1