### PR TITLE
Add full NES and N64 catalogs

### DIFF
--- a/websites/switch-catalog/index.html
+++ b/websites/switch-catalog/index.html
@@ -24,25 +24,187 @@
       <h2>NES Classics</h2>
       <div class="game-grid">
         <details class="game-card">
-          <summary>Super Mario Bros. 3 (1988)</summary>
-          <p class="genre">Platformer</p>
-          <p><strong>If you liked:</strong> Super Mario Bros. Wonder's clever levels</p>
-          <p>Mario and Luigi hop through eight themed worlds brimming with secrets and suit power-ups.</p>
-          <p>Bowser kidnaps the Kings; the brothers reclaim each kingdom to rescue Princess Peach.</p>
-          <p>The game showcased the NES at its peak with world maps and varied play styles.</p>
-          <p>Tight controls and save states make revisiting levels a breezy challenge.</p>
+          <summary>Super Mario Bros. 3 (1990)</summary>
+          <p class="genre">Side-scroll Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario 3D World + Bowser’s Fury</p>
+          <p>Mario’s movable map sends you through 8 themed worlds packed with power-ups like the Tanooki Suit. Levels rarely top five minutes.</p>
+          <p>Bowser kidnaps the kings; the bros. chase him across the Mushroom World and beyond.</p>
+          <p>Nintendo R&D4 pushed the NES with diagonal scrolling and huge sprites late in its life.</p>
+          <p>Tight controls and frequent checkpoints make quick sessions stress-free.</p>
         </details>
         <details class="game-card">
-          <summary>Metroid (1986)</summary>
+          <summary>Kirby’s Adventure (1993)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> Kirby and the Forgotten Land</p>
+          <p>Kirby inhales foes to copy more than 20 abilities; bright graphics show off late-NES color tricks.</p>
+          <p>Kirby repairs Dream Land’s stolen Star Rod to end King Dedede’s “nightmare cure.”</p>
+          <p>HAL’s last 8-bit game debuted Kirby’s copy mechanic.</p>
+          <p>Forgiving lives and mid-level saves are perfect for casual, 15-minute play.</p>
+        </details>
+        <details class="game-card">
+          <summary>The Legend of Zelda (1986)</summary>
+          <p class="genre">Top-down Adventure</p>
+          <p><strong>If you liked:</strong> Tunic</p>
+          <p>Open-world exploration—burn bushes, bomb walls, find secrets in any order.</p>
+          <p>Link gathers eight Triforce fragments to rescue Princess Zelda from Ganon.</p>
+          <p>Miyamoto invented battery saves here, letting longer quests survive power-offs.</p>
+          <p>Modern rewind/suspend lets you dip in for one dungeon room at a time.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid (1987)</summary>
+          <p class="genre">Exploration Action</p>
+          <p><strong>If you liked:</strong> Metroid Dread</p>
+          <p>Non-linear maze of corridors where new beams unlock shortcuts.</p>
+          <p>Bounty hunter Samus stops the Space Pirates’ bio-weapon on planet Zebes.</p>
+          <p>Staff hid “Justin Bailey” code and the “Samus-is-a-woman” reveal as early Easter eggs.</p>
+          <p>Mapless wandering feels tense, but save states tame the backtracking.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Bros. (1985)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Maker 2 (classic courses)</p>
+          <p>The side-scrolling template every 2-D platformer still copies.</p>
+          <p>Mario crosses eight worlds to free Peach from Bowser’s first castle.</p>
+          <p>A 1983 Kung Fu port prototype morphed into Nintendo’s global smash.</p>
+          <p>One world takes about six minutes—ideal micro-bursts.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Bros. 2 (1988)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Captain Toad: Treasure Tracker (object-centric)</p>
+          <p>Four heroes pluck veggies and ride flying carpets in dreamlike stages.</p>
+          <p>Mario awakens in Subcon to topple tyrant Wart.</p>
+          <p>Re-skinned from Doki Doki Panic for the West, then canonized worldwide.</p>
+          <p>Play styles vary by character; individual levels fit five-minute breaks.</p>
+        </details>
+        <details class="game-card">
+          <summary>Punch-Out!! Featuring Mr. Dream (1990)</summary>
+          <p class="genre">Timing Boxer</p>
+          <p><strong>If you liked:</strong> ARMS (pattern-reading bouts)</p>
+          <p>Memorize tells and strike when guards open.</p>
+          <p>Little Mac climbs the WVBA ladder to face mystery champ Mr. Dream.</p>
+          <p>Lost Mike Tyson’s license in 1990, hence the rebrand.</p>
+          <p>Single fight = 3 minutes; perfect snack-size challenge.</p>
+        </details>
+        <details class="game-card">
+          <summary>StarTropics (1990)</summary>
           <p class="genre">Action-Adventure</p>
-          <p><strong>If you liked:</strong> Metroid Dread's labyrinthine maps</p>
-          <p>Samus explores Planet Zebes, acquiring upgrades to infiltrate Mother Brain's lair.</p>
-          <p>The mission is sparse on text but steeped in eerie isolation.</p>
-          <p>Metroid pioneered non-linear exploration and atmosphere on the NES.</p>
-          <p>Modern rewind features tame the original's high difficulty.</p>
+          <p><strong>If you liked:</strong> The Touryst</p>
+          <p>Island-hopping Zelda-like with yo-yo combat and puzzly dungeons.</p>
+          <p>Mike Jones seeks his abducted archaeologist uncle across the C-Islands.</p>
+          <p>Designed specifically for the U.S.; never released in Japan.</p>
+          <p>Chapters auto-save, so one dungeon room or overworld segment is plenty per sitting.</p>
+        </details>
+        <details class="game-card">
+          <summary>Blaster Master (1988)</summary>
+          <p class="genre">Hybrid Platformer/Shooter</p>
+          <p><strong>If you liked:</strong> Blaster Master Zero</p>
+          <p>Swap between tank exploration and on-foot shooter mini-dungeons.</p>
+          <p>Jason pursues radioactive frog Fred into mutant-ridden caverns.</p>
+          <p>Sunsoft mashed two prototypes after U.S. marketers asked for a bigger story.</p>
+          <p>Each area splits into bite-size sections you can clear in 10–15 minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Crystalis (1990)</summary>
+          <p class="genre">Action RPG</p>
+          <p><strong>If you liked:</strong> Hyper Light Drifter</p>
+          <p>Elemental swords and real-time combat in a post-apocalyptic fantasy.</p>
+          <p>A cryogenically frozen hero stops the “Evil Empire” from reviving weapon TOWER.</p>
+          <p>SNK’s answer to Zelda added day-night cycles and voice snippets.</p>
+          <p>Frequent inns let you save/grind briefly, then log off.</p>
+        </details>
+        <details class="game-card">
+          <summary>River City Ransom (1989)</summary>
+          <p class="genre">Beat ’em Up / RPG</p>
+          <p><strong>If you liked:</strong> River City Girls</p>
+          <p>Punch goons, grab cash, buy sushi for stats in open-city brawls.</p>
+          <p>High-schoolers Alex &amp; Ryan rescue Ryan’s girlfriend from Slick’s gang.</p>
+          <p>Technōs fused Double Dragon combat with light RPG menus.</p>
+          <p>Streets are short loops—perfect 5-minute skirmishes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Dr. Mario (1990)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Puyo Puyo Tetris 2</p>
+          <p>Flip capsules to cure color-coded viruses before the bottle fills.</p>
+          <p>Mario moonlights as an M.D. battling a viral outbreak.</p>
+          <p>Launched alongside Game Boy version to push link-cable competition.</p>
+          <p>One round lasts 2–3 minutes—ideal “just one more” break.</p>
+        </details>
+        <details class="game-card">
+          <summary>Tetris (1989)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Tetris Effect Connected</p>
+          <p>The block-stacking evergreen.</p>
+          <p>No narrative; pure score chase.</p>
+          <p>Nintendo’s NES port won the “Tetris wars” of 1989 cartridge rights.</p>
+          <p>Marathon or 150-line goal fits any time slot.</p>
+        </details>
+        <details class="game-card">
+          <summary>Excitebike (1984)</summary>
+          <p class="genre">Racer / Time Trial</p>
+          <p><strong>If you liked:</strong> Trials Rising</p>
+          <p>Solo motocross where turbo overheat management is key.</p>
+          <p>Compete for best time across 5 tracks.</p>
+          <p>Miyamoto added track edit mode years before user-generated content was a buzzword.</p>
+          <p>A lap is under 30 seconds—great speed-run snack.</p>
+        </details>
+        <details class="game-card">
+          <summary>Balloon Fight (1984)</summary>
+          <p class="genre">Arcade Action</p>
+          <p><strong>If you liked:</strong> Killer Queen Black (floaty combat)</p>
+          <p>Flap to pop rivals’ balloons while dodging lightning.</p>
+          <p>Endless arcade survival; no plot required.</p>
+          <p>Inspired by Williams’ Joust, coded by future Game Boy creator Gunpei Yokoi.</p>
+          <p>One life can last 30 seconds or five minutes—your call.</p>
+        </details>
+        <details class="game-card">
+          <summary>Donkey Kong (1981)</summary>
+          <p class="genre">Arcade Platformer</p>
+          <p><strong>If you liked:</strong> Donkey Kong Country: Tropical Freeze (legacy)</p>
+          <p>Leap girders and ladders to save Pauline.</p>
+          <p>Carpenter Jumpman faces rogue ape Donkey Kong.</p>
+          <p>Nintendo’s breakthrough U.S. hit birthed both Mario and legal battles with Universal.</p>
+          <p>Four short boards loop forever—perfect micro-challenge.</p>
+        </details>
+        <details class="game-card">
+          <summary>Gradius (1986)</summary>
+          <p class="genre">Horizontal Shooter</p>
+          <p><strong>If you liked:</strong> Sky Force Reloaded</p>
+          <p>Power-up bar lets you choose upgrades mid-fight.</p>
+          <p>Vic Viper defends planet Gradius from the Bacterion menace.</p>
+          <p>Konami coined the “Konami Code” here for quick power-ups.</p>
+          <p>One stage ≈ 6 minutes; difficulty scales but rewind eases pain.</p>
+        </details>
+        <details class="game-card">
+          <summary>EarthBound Beginnings (1989/2015)</summary>
+          <p class="genre">Turn-based RPG</p>
+          <p><strong>If you liked:</strong> Undertale</p>
+          <p>Quirky suburban kids vs. aliens with baseball bats and PSI.</p>
+          <p>Ninten gathers melodies to pacify alien leader Giygas.</p>
+          <p>Canceled U.S. NES cart resurfaced officially on Wii U and NSO decades later.</p>
+          <p>Save points every town make 15-minute grinding sessions doable.</p>
+        </details>
+        <details class="game-card">
+          <summary>Wario’s Woods (1994)</summary>
+          <p class="genre">Action-Puzzle</p>
+          <p><strong>If you liked:</strong> Lumines Remastered</p>
+          <p>Toad scrambles in-stack to line up monsters before Wario drops more.</p>
+          <p>Toad overthrows Wario’s forest domination block by block.</p>
+          <p>Last licensed NES release in North America; coded entirely by Nintendo late in ’94.</p>
+          <p>Timer-driven rounds tap-out at three minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Zelda II: The Adventure of Link (1988)</summary>
+          <p class="genre">Action-RPG / Side-scroll</p>
+          <p><strong>If you liked:</strong> Hollow Knight (risk-reward swordplay)</p>
+          <p>Overworld RPG meets 2-D sword duels and magic.</p>
+          <p>Link restores crystals to six palaces to awaken sleeping Zelda.</p>
+          <p>Miyamoto experimented with EXP systems here before shelving them for later Zeldas.</p>
+          <p>Save anywhere plus rewind sands off its legendary edge.</p>
         </details>
       </div>
-    </section>
+      </section>
 
     <section id="snes">
       <h2>Super NES Essentials</h2>
@@ -69,25 +231,187 @@
     </section>
 
     <section id="n64">
-      <h2>Nintendo 64 Favorites</h2>
+      <h2>Nintendo 64 – Nintendo Classics</h2>
       <div class="game-grid">
+        <details class="game-card">
+          <summary>The Legend of Zelda: Ocarina of Time (1998)</summary>
+          <p class="genre">3-D Action-Adventure</p>
+          <p><strong>If you liked:</strong> Tears of the Kingdom’s dungeons &amp; puzzles</p>
+          <p>A landmark 3-D quest that teaches you Z-targeting, lock-on combat, and horse riding in minutes. Dungeons are bite-sized enough to clear a room or two in a coffee break.</p>
+          <p>Young Link gathers mystical stones, then time-travels seven years to stop Ganondorf’s rise.</p>
+          <p>Began as a Mario 64 tech test; EAD rewrote N64’s engine around cinematic camera work.</p>
+          <p>Still silky at 30 fps in the emulator; suspend states let you hop out whenever life calls.</p>
+        </details>
+        <details class="game-card">
+          <summary>Paper Mario (2001)</summary>
+          <p class="genre">Turn-based RPG / Adventure</p>
+          <p><strong>If you liked:</strong> Mario &amp; Luigi: Dream Team</p>
+          <p>Storybook-flat Mushroom Kingdom where timed button presses keep battles snappy.</p>
+          <p>Bowser steals the Star Rod; Mario allies with Goombas, Bob-ombs, and Boos to restore wishes.</p>
+          <p>Intelligent Systems pivoted from a realistic 64-bit RPG to pop-up-book visuals to stand out late in the N64 life cycle.</p>
+          <p>Chapters last ~45 min, but save blocks appear every few rooms—perfect pick-up-and-play.</p>
+        </details>
+        <details class="game-card">
+          <summary>The Legend of Zelda: Majora’s Mask (2000)</summary>
+          <p class="genre">Adventure / Time-loop</p>
+          <p><strong>If you liked:</strong> Outer Wilds for loops, TOTK for tone shifts</p>
+          <p>A darker, three-day countdown where you reset time to solve side quests.</p>
+          <p>Link must stop the moon from crushing Termina by pacifying four troubled giants.</p>
+          <p>Built in 18 months by re-using Ocarina’s engine; introduced the now-famous Zelda time mechanics.</p>
+          <p>Sessions feel like self-contained “Groundhog Day” errands—ideal for 20-minute loops.</p>
+        </details>
         <details class="game-card">
           <summary>Super Mario 64 (1996)</summary>
           <p class="genre">3-D Platformer</p>
-          <p><strong>If you liked:</strong> Super Mario Odyssey’s open-ended playgrounds</p>
-          <p>Mario leaps through paintings in Peach’s Castle, tackling missions in sprawling courses.</p>
-          <p>The barebones story sets up a hunt for 120 Power Stars to oust Bowser.</p>
-          <p>Defined free-roaming 3D platforming and showcased analog control on N64.</p>
-          <p>The camera can be clunky, but save states help master tough stars.</p>
+          <p><strong>If you liked:</strong> Super Mario Odyssey</p>
+          <p>Collect 120 Power Stars across 15 worlds; most stars take &lt;10 min.</p>
+          <p>Peach invites Mario to cake; Bowser hijacks her castle’s paintings.</p>
+          <p>Shigeru Miyamoto’s leap into 3-D invented analog-stick platforming standards overnight.</p>
+          <p>Always-smooth controls; state save lets you chase a single star when short on time.</p>
         </details>
         <details class="game-card">
-          <summary>The Legend of Zelda: Ocarina of Time (1998)</summary>
-          <p class="genre">Action-Adventure</p>
-          <p><strong>If you liked:</strong> Breath of the Wild’s sprawling quest</p>
-          <p>Young Link travels through time to thwart Ganondorf, exploring dungeons with puzzle-filled rooms.</p>
-          <p>The classic tale sees Link awaken as the Hero of Time to seal away evil.</p>
-          <p>Considered a landmark for 3D adventure design, influencing countless games.</p>
-          <p>Modern features reduce frustration from some obtuse moments.</p>
+          <summary>Pokémon Snap (1999)</summary>
+          <p class="genre">On-Rails Photo Adventure</p>
+          <p><strong>If you liked:</strong> New Pokémon Snap</p>
+          <p>Ride a rail cart and shoot pictures, not Poké Balls.</p>
+          <p>Prof. Oak sends you to catalog wild Pokémon with the best pose.</p>
+          <p>HAL Laboratory reused an internal “Jack and the Beanstalk” rail demo; Nintendo grafted Pokémon onto it mid-dev.</p>
+          <p>Courses are five minutes tops—perfect micro sessions hunting that Charizard shot.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby 64: The Crystal Shards (2000)</summary>
+          <p class="genre">2.5-D Platformer</p>
+          <p><strong>If you liked:</strong> Kirby and the Forgotten Land</p>
+          <p>Combine two powers for 30+ hybrid abilities.</p>
+          <p>Kirby rebuilds Ribbon’s shattered crystal to stop Dark Matter.</p>
+          <p>HAL’s first 3-D-model Kirby kept SNES-style gameplay in a 3-D camera rail.</p>
+          <p>Short, colorful stages; difficulty stays mellow until the hidden final boss.</p>
+        </details>
+        <details class="game-card">
+          <summary>Banjo-Kazooie (1998)</summary>
+          <p class="genre">Collect-A-Thon Platformer</p>
+          <p><strong>If you liked:</strong> A Hat in Time</p>
+          <p>Explore nine hub worlds, swapping bear &amp; bird moves on the fly.</p>
+          <p>Witch Gruntilda kidnaps Banjo’s sister for a beauty swap spell.</p>
+          <p>Rare’s “Dream” project morphed into a Mario-64 rival and sold 3 M+.</p>
+          <p>Jigsaw pieces take 2 – 5 min each; you can exit anytime with no penalty.</p>
+        </details>
+        <details class="game-card">
+          <summary>Star Fox 64 (1997)</summary>
+          <p class="genre">Rail Shooter</p>
+          <p><strong>If you liked:</strong> Panzer Dragoon: Remake</p>
+          <p>Barrel-roll through branching space routes and cheesy voice lines.</p>
+          <p>Team Star Fox repels Andross from the Lylat system.</p>
+          <p>First game with the N64 Rumble Pak; defined haptic feedback.</p>
+          <p>A full run is &lt;45 min; levels average five.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Kart 64 (1997)</summary>
+          <p class="genre">Kart Racing</p>
+          <p><strong>If you liked:</strong> Mario Kart 8 Deluxe</p>
+          <p>Drifting &amp; items in 16 tracks vs. CPU.</p>
+          <p>Mushroom Cup to Rainbow Road—no plot needed.</p>
+          <p>One of the earliest 4-player console staples; introduced 3-D track designs.</p>
+          <p>Single GP cup fits a 15-minute break; rubber-band AI stays fair.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon Puzzle League (2000)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Tetris Effect Connected competitive mode</p>
+          <p>Panel-de-Pon block-match with Pikachu cheerleading.</p>
+          <p>Ash competes in the Puzzle League to become Champion.</p>
+          <p>Developed by Nintendo Software Tech in Redmond—their first title.</p>
+          <p>Endless mode or a single Versus battle scratches the 10-minute itch.</p>
+        </details>
+        <details class="game-card">
+          <summary>Wave Race 64 (1996)</summary>
+          <p class="genre">Water Racer</p>
+          <p><strong>If you liked:</strong> Wave Race BlueStorm HD on Switch 2</p>
+          <p>Dynamic waves make every lap feel new.</p>
+          <p>Tour the globe’s jet-ski circuit to be #1.</p>
+          <p>Used an early “wave physics” demo that wowed Miyamoto into green-lighting.</p>
+          <p>Grand Prix cups are ~12 min; vibe is chill not punishing.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Golf (1999)</summary>
+          <p class="genre">Sports Sim</p>
+          <p><strong>If you liked:</strong> Golf Story</p>
+          <p>Accessible swings plus RPG-lite career.</p>
+          <p>Become Mushroom Kingdom champ across six courses.</p>
+          <p>Camelot built an engine flexible enough to spawn GBA &amp; 3DS sequels.</p>
+          <p>A single 3-hole “club set” is a 10-minute palate cleanser.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Tennis (2000)</summary>
+          <p class="genre">Sports</p>
+          <p><strong>If you liked:</strong> Mario Tennis Aces offline</p>
+          <p>Simple topspin/slice with charming courts &amp; characters.</p>
+          <p>Win the Star Tourney to face Bowser.</p>
+          <p>Same Camelot team; introduced Waluigi to the world.</p>
+          <p>Best-of-3 match takes ~8 min, perfect between tasks.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pilotwings 64 (1996)</summary>
+          <p class="genre">Flight Score-Attack</p>
+          <p><strong>If you liked:</strong> Pilotwings Resort</p>
+          <p>Rocket belt, gyrocopter, and hang-glider stunt scoring.</p>
+          <p>Earn licenses from lightly comedic instructors.</p>
+          <p>Nintendo &amp; Paradigm Simulation fusion project to show off 3-D vistas.</p>
+          <p>Each mission is ~5 min; sandbox “Birdman” mode is pure zen.</p>
+        </details>
+        <details class="game-card">
+          <summary>F-Zero X (1998)</summary>
+          <p class="genre">Futuristic Racer</p>
+          <p><strong>If you liked:</strong> FAST RMX</p>
+          <p>60 fps anti-gravity speed at 1000 kph.</p>
+          <p>Win the GP, claim Captain Falcon’s bounty.</p>
+          <p>Built on a bespoke micro-polygon engine that predated GX.</p>
+          <p>4-lap cup &lt;10 min; difficulty options let you stay comfy.</p>
+        </details>
+        <details class="game-card">
+          <summary>Yoshi’s Story (1998)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Yoshi’s Crafted World</p>
+          <p>Eat 30 fruit any route you like in fabric dioramas.</p>
+          <p>Baby Bowser steals the Super Happy Tree; six Yoshis cheer up the island.</p>
+          <p>Began as “Yoshi’s Island 64,” switched to pop-up book motif mid-way.</p>
+          <p>Each page is 5-10 min; forgiving lives make it stress-free.</p>
+        </details>
+        <details class="game-card">
+          <summary>1080º Snowboarding (1998)</summary>
+          <p class="genre">Extreme Sports</p>
+          <p><strong>If you liked:</strong> SSX 3</p>
+          <p>Carve realistic slopes and land stylish spins.</p>
+          <p>Win the Mountain Village comp circuit.</p>
+          <p>Nintendo’s answer to the Tony Hawk boom, built by the Wave Race team.</p>
+          <p>Time trials are &lt;2 min; trick mode scratches repetition-friendly goals.</p>
+        </details>
+        <details class="game-card">
+          <summary>Dr. Mario 64 (2001)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Puyo Puyo Tetris 2</p>
+          <p>Classic pill-drop rhythm with story &amp; VS.</p>
+          <p>Dr. Mario and Wario race to cure Flu Virus outbreak.</p>
+          <p>Last first-party N64 release, co-dev with Treasure.</p>
+          <p>Endless mode scales gently—easy to bail after one fever.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon Stadium 2 (2001)</summary>
+          <p class="genre">Battler / Mini-Game Suite</p>
+          <p><strong>If you liked:</strong> Pokémon Showdown + party games</p>
+          <p>Import (or rent) teams for 3-v-3 tournaments and 12 goofy mini-games.</p>
+          <p>Beat the Gym Leader Castle and rival to face Mewtwo.</p>
+          <p>Genius Sonority’s 3-D showcase for Gen I-II sprites.</p>
+          <p>Mini-games are 30-second bursts; Cup battles save after each round.</p>
+        </details>
+        <details class="game-card">
+          <summary>Blast Corps (1997)</summary>
+          <p class="genre">Destruction Puzzle-Action</p>
+          <p><strong>If you liked:</strong> Teardown (physics carnage)</p>
+          <p>Clear paths for an out-of-control nuke truck by demolishing everything.</p>
+          <p>No grand narrative—just stop the runaway carrier before disaster.</p>
+          <p>Rare prototyped as a “fire truck” game; morphed into sandbox demolition.</p>
+          <p>Missions last 2-4 min; gold medals add optional challenge if you feel spicy.</p>
         </details>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- expand NES Classics section with a 20 game lineup
- replace Nintendo 64 block with 20 game "Nintendo Classics" list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eebcb6e208330afc99b6b2cccf307