### PR TITLE
Add extensive Nintendo classics catalog

### DIFF
--- a/websites/switch-catalog/index.html
+++ b/websites/switch-catalog/index.html
@@ -207,16 +207,17 @@
       </section>
 
     <section id="snes">
-      <h2>Super NES Essentials</h2>
+      <h2>Super Nintendo Entertainment System – Nintendo Classics</h2>
+      <p>(solo-friendly picks you can dip into for 10- to 60-minute sessions; all titles are in the current SNES app on Switch Online + Expansion Pack as of June 2025)</p>
       <div class="game-grid">
         <details class="game-card">
           <summary>The Legend of Zelda: A Link to the Past (1991)</summary>
           <p class="genre">Top-down Action-Adventure</p>
           <p><strong>If you liked:</strong> Tears of the Kingdom’s shrine brainteasers</p>
-          <p>A sprawling 2-D Hyrule packed with secret-stuffed dungeons and gadget-driven puzzles.</p>
+          <p>A sprawling 2-D Hyrule packed with secret-stuffed dungeons and gadget-driven puzzles. Each dungeon room is a bite-size objective—perfect pause points.</p>
           <p>Link collects three pendants, then rescues the seven Maidens to seal Ganon in the Dark World.</p>
-          <p>First Zelda to add a parallel world; R&D4 pioneered light/dark map layering on the SNES.</p>
-          <p>Snappy sword swings and unlimited save states keep difficulty fair while rewarding exploration.</p>
+          <p>First Zelda to add a parallel world; R&D4 pioneered “light↔dark” map layering on the SNES.</p>
+          <p>Snappy sword swings and unlimited save states keep difficulty fair while still rewarding exploration.</p>
         </details>
         <details class="game-card">
           <summary>Super Mario World (1990)</summary>
@@ -224,8 +225,170 @@
           <p><strong>If you liked:</strong> Super Mario Bros. Wonder’s feel-good hopping</p>
           <p>Caped Mario glides through 96 exits across Dinosaur Land. Most levels clock in under five minutes.</p>
           <p>Bowser kidnaps Peach and Yoshi’s buddies; Mario frees them one zone at a time.</p>
-          <p>Launch title that sold over 20M copies, proving SNES’s Mode 7 and color depth.</p>
+          <p>Launch title that sold over 20 M copies, proving SNES’s Mode 7 and color depth.</p>
           <p>Tight controls make even quick sessions satisfying—just chase one secret exit and bail.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Metroid (1994)</summary>
+          <p class="genre">Exploration Action</p>
+          <p><strong>If you liked:</strong> Hollow Knight for map-wide ability gating</p>
+          <p>Samus upgrades her way through planet Zebes, linking regions via clever shortcuts. Rooms are designed for “one more corridor” bursts.</p>
+          <p>Space Pirate leader Mother Brain revives the last Metroid; Samus stops the bio-weapon project.</p>
+          <p>Nintendo EAD reused elements from the canceled SNES “Metroid III” prototype, shaping modern Metroidvanias.</p>
+          <p>Suspend points and rewind tame its back-tracking while keeping the suspense intact.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario World 2: Yoshi’s Island (1995)</summary>
+          <p class="genre">Platformer / Collect-a-thon</p>
+          <p><strong>If you liked:</strong> Yoshi’s Crafted World</p>
+          <p>Crayon-bright levels where Yoshi tosses eggs and flutters to secrets. Each stage hides 30 flowers/coins for completionists.</p>
+          <p>Yoshi escorts Baby Mario across six worlds to reunite the twins and foil Baby Bowser.</p>
+          <p>Custom Super FX 2 chip let artists sketch hand-drawn animation that trumped pre-rendered trends.</p>
+          <p>Stages are relaxed; you can clear one or just hunt collectibles during a short break.</p>
+        </details>
+        <details class="game-card">
+          <summary>EarthBound (1995)</summary>
+          <p class="genre">Turn-based RPG</p>
+          <p><strong>If you liked:</strong> Undertale’s quirky humor</p>
+          <p>Contemporary suburbia RPG where baseball bats replace swords and ATMs replace treasure chests. Town segments are short and save phones abound.</p>
+          <p>Ness and friends gather eight melodies to defeat alien horror Giygas before time unravels.</p>
+          <p>Shigesato Itoi mixed Americana parody with Dragon Quest mechanics; bombed in ’95 but earned cult love.</p>
+          <p>Grinding is minimal; auto-win triggers for weak foes let 15-minute sessions feel productive.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby Super Star (1996)</summary>
+          <p class="genre">Action Platformer Anthology</p>
+          <p><strong>If you liked:</strong> Kirby and the Forgotten Land’s bite-size variety</p>
+          <p>Eight mini-campaigns—from simple sprint “Spring Breeze” to treasure-hunt “Great Cave Offensive.”</p>
+          <p>King Dedede steals Dream Land’s food (again), Marx tricks Kirby into summoning Galactic Nova, and Meta Knight duels him over Halberd’s fate.</p>
+          <p>HAL pushed SNES cart size to fit fighting-game-style copy moves and two-player co-op.</p>
+          <p>Individual modes last 5-20 minutes—ideal sampler platter gaming.</p>
+        </details>
+        <details class="game-card">
+          <summary>Donkey Kong Country 2: Diddy’s Kong Quest (1995)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Rayman Legends for momentum &amp; secrets</p>
+          <p>Tag-team Diddy &amp; Dixie swing, spin, and blast through pirate-themed stages. Hidden DK Coins and bonus rooms add replay hooks.</p>
+          <p>K. Rool kidnaps DK; the junior Kongs storm Crocodile Isle to ransom him.</p>
+          <p>Rare’s ACM CGI pushed 16-bit visuals beyond rivals; soundtrack became a cult classic.</p>
+          <p>Most levels wrap in under six minutes; you choose simple finish or secret sweep.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Kart (1992)</summary>
+          <p class="genre">Kart Racer</p>
+          <p><strong>If you liked:</strong> Mario Kart 8 Deluxe offline</p>
+          <p>Mode 7 courses and power-item chaos for quick Grands Prix. Speed classes adjust challenge easily.</p>
+          <p>Peach’s Castle hosts the first Mushroom Cup; no narrative needed.</p>
+          <p>Invented the kart-racer sub-genre, selling 8.7 M on SNES alone.</p>
+          <p>One 5-race cup ≈ 12 minutes—perfect coffee-break adrenaline.</p>
+        </details>
+        <details class="game-card">
+          <summary>Star Fox (1993)</summary>
+          <p class="genre">Rail Shooter</p>
+          <p><strong>If you liked:</strong> Panzer Dragoon: Remake</p>
+          <p>Fox McCloud pilots the Arwing through branching space routes and voice-barks. Each route is a self-contained 30-minute run.</p>
+          <p>Team Star Fox thwarts Andross’s invasion of the Lylat system.</p>
+          <p>Super FX chip delivered console 3-D; Miyamoto storyboarded like an anime episode.</p>
+          <p>Levels are 5-minute burst thrills; save states let you master tricky boss tells.</p>
+        </details>
+        <details class="game-card">
+          <summary>F-Zero (1990)</summary>
+          <p class="genre">Futuristic Racer</p>
+          <p><strong>If you liked:</strong> FAST RMX</p>
+          <p>400 km/h hovercraft laps across Mode 7 mazes. Three circuits scale from easy to expert.</p>
+          <p>Captain Falcon &amp; rivals chase prize money in a no-rules league.</p>
+          <p>Launch showcase for Mode 7 scrolling convinced devs 3-D racers could work.</p>
+          <p>A full circuit is &lt;15 minutes; you control difficulty via league choice.</p>
+        </details>
+        <details class="game-card">
+          <summary>Panel de Pon (1995)</summary>
+          <p class="genre">Match-3 Puzzle</p>
+          <p><strong>If you liked:</strong> Tetris Effect: Connected versus</p>
+          <p>Swap colored panels to chain clears and bury opponents. Endless &amp; Time-Trial modes suit solo play.</p>
+          <p>Fairy Lip battles rivals to restore the rainbow of Popples.</p>
+          <p>Localized as Tetris Attack but NSO uses the original branding with English text.</p>
+          <p>One round is 2-3 minutes—easy to squeeze in any spare moment.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Punch-Out!! (1994)</summary>
+          <p class="genre">Pattern Boxer</p>
+          <p><strong>If you liked:</strong> ARMS offline</p>
+          <p>Read tells, dodge, then counter for star uppercuts. Title Defense ladder gives 16 distinct puzzles.</p>
+          <p>Little Mac climbs four cups to face Bruiser twins Rick &amp; Nick.</p>
+          <p>Nintendo R&amp;D3 built an SA-1 chip for smoother sprites and re-recorded voice taunts.</p>
+          <p>Each match lasts three minutes max—bite-size bosses you can retry instantly.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby’s Dream Course (1994)</summary>
+          <p class="genre">Isometric Golf-Puzzle</p>
+          <p><strong>If you liked:</strong> Golf Story mini-games</p>
+          <p>Guide ball-form Kirby through obstacle-filled greens, copying enemies for trick shots.</p>
+          <p>Kirby golfs through Wispy Woods’s land to stop King Dedede… via putting.</p>
+          <p>Originally “Special Tee Shot” before HAL reskinned it with Kirby for charm.</p>
+          <p>Single hole = 2 minutes; puzzle-golf mashup is low-stress and colorful.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pilotwings (1990)</summary>
+          <p class="genre">Flight Score-Attack</p>
+          <p><strong>If you liked:</strong> Microsoft Flight Simulator lite challenges</p>
+          <p>Earn licenses in skydiving, rocket belt, biplane, and hang-glider tests. Missions grade landings and rings hit.</p>
+          <p>No real plot—just graduate from Light to Platinum wings.</p>
+          <p>EAD used Mode 7 to sell the SNES’s 3-D illusion pre-Star Fox.</p>
+          <p>Trials last 3-5 minutes; rewind removes frustration from botched touchdowns.</p>
+        </details>
+        <details class="game-card">
+          <summary>Star Fox 2 (2017/1995)</summary>
+          <p class="genre">3-D Strategy Shooter</p>
+          <p><strong>If you liked:</strong> FTL for map management + dogfights</p>
+          <p>Real-time Lylat map where you intercept missiles, then dive into 3-D battles. Auto-generated routes keep runs fresh.</p>
+          <p>Star Wolf distracts you while Andross’s forces approach Corneria; stop them before planet HP hits zero.</p>
+          <p>Canceled in ’95, finished by original team and finally released on SNES Classic/NSO in 2017.</p>
+          <p>One full campaign is ~30 minutes; perfect “roguelike-lite” loop.</p>
+        </details>
+        <details class="game-card">
+          <summary>Donkey Kong Country (1994)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Sackboy: A Big Adventure</p>
+          <p>DK &amp; Diddy barrel-blast through 40 levels of jungle, mine carts, and ice caves. Animal buddies add variety.</p>
+          <p>K. Rool steals the banana hoard; duo fights back for potassium justice.</p>
+          <p>Rare’s pre-rendered CGI stunned players and revitalized DK IP.</p>
+          <p>Levels average 4–6 minutes; crank up lives if you want low-stress swings.</p>
+        </details>
+        <details class="game-card">
+          <summary>Breath of Fire II (1994)</summary>
+          <p class="genre">Turn-based JRPG</p>
+          <p><strong>If you liked:</strong> Octopath Traveler retro vibes</p>
+          <p>Elemental dragons, town-building, and buddy fusion give classic yet fresh mechanics. Save anywhere via NSO menu.</p>
+          <p>Ryu and friends expose a corrupt Church masking demon lord Deathevan.</p>
+          <p>Capcom rushed release, causing quirky translation now cherished by fans.</p>
+          <p>Dungeons are short; suspend saves let you clear a floor at a time.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby’s Dream Land 3 (1997)</summary>
+          <p class="genre">Platformer</p>
+          <p><strong>If you liked:</strong> Kirby Star Allies</p>
+          <p>Pastel crayon art and animal-friend combos across six worlds. Each stage hides a mission for 100% ending.</p>
+          <p>Dark Matter returns; Kirby gathers Heart Stars to purify Dream Land.</p>
+          <p>Late-era SNES game using SA-1 for smoother scrolling and huge sprites.</p>
+          <p>Very forgiving; you can knock out one mission in 10 minutes and quit happy.</p>
+        </details>
+        <details class="game-card">
+          <summary>Harvest Moon (1996)</summary>
+          <p class="genre">Life-Sim Farm-RPG</p>
+          <p><strong>If you liked:</strong> Stardew Valley</p>
+          <p>Plant, water, and ship crops while wooing townsfolk in a 16-bit year. Day cycle lets you save every night.</p>
+          <p>You inherit a rundown farm; restore it and choose marriage by year’s end.</p>
+          <p>Original creator Yasuhiro Wada coined “non-violent, slow life” design here.</p>
+          <p>Single in-game day ≈ 5 minutes—ideal for micro-management breaks.</p>
+        </details>
+        <details class="game-card">
+          <summary>Stunt Race FX (1994)</summary>
+          <p class="genre">Arcade Racer</p>
+          <p><strong>If you liked:</strong> Hot Wheels Unleashed</p>
+          <p>Face-tracked cars tackle twisty, bumpy physics courses using Super FX2 chip. Speed Tracks and Battle Trax diversify races.</p>
+          <p>No narrative—just a medals quest across 12 circuits.</p>
+          <p>One of the earliest polygon racers on console; tech informed Star Fox 2 refinements.</p>
+          <p>Races last ~2 minutes; loose handling is silly fun, not punishing.</p>
         </details>
       </div>
     </section>
@@ -417,49 +580,375 @@
     </section>
 
     <section id="gb">
-      <h2>Game Boy Gems</h2>
+      <h2>Game Boy / Game Boy Color – Nintendo Classics</h2>
+      <p>(solo-friendly, moderate-challenge picks you can play in 10- to 60-minute bursts; all titles are already in the Switch Online Game Boy app as of June 2025, or have been officially announced and dated for the next quarterly drop)</p>
       <div class="game-grid">
         <details class="game-card">
-          <summary>The Legend of Zelda: Link's Awakening (1993)</summary>
-          <p class="genre">Action-Adventure</p>
-          <p><strong>If you liked:</strong> The handheld feel of Link Between Worlds</p>
-          <p>Link washes ashore on Koholint Island and must awaken the Wind Fish to escape.</p>
-          <p>The dreamlike narrative includes quirky cameos and mini-games.</p>
-          <p>One of the most ambitious Game Boy titles, pushing the hardware’s limits.</p>
-          <p>D-pad movement is a bit stiff, but quick-save lets you explore at your own pace.</p>
+          <summary>The Legend of Zelda: Link’s Awakening DX (1998)</summary>
+          <p class="genre">Top-down Action-Adventure</p>
+          <p><strong>If you liked:</strong> Tunic’s puzzles</p>
+          <p>A colorised director’s cut of the original handheld Zelda, brimming with clever item gating and optional dungeons.</p>
+          <p>Link shipwrecks on Koholint and must wake the slumbering Wind Fish to escape the dream world.</p>
+          <p>First portable Zelda remake; added a photo side quest for the Game Boy Printer.</p>
+          <p>Overworld loops back on itself every few steps—perfect for 15-minute exploration spurts.</p>
+        </details>
+        <details class="game-card">
+          <summary>The Legend of Zelda: Oracle of Ages (2001)</summary>
+          <p class="genre">Puzzle-Heavy Adventure</p>
+          <p><strong>If you liked:</strong> Tears of the Kingdom’s shrines</p>
+          <p>Time-travel puzzles dominate this Capcom-developed quest.</p>
+          <p>Link teams with Nayru to stop the sorceress Veran warping Labrynna’s past.</p>
+          <p>One half of a linked-cartridge duo designed to cross-save with Oracle of Seasons.</p>
+          <p>Individual time-shift rooms play out in 5-minute bites; passwords let you resume anywhere.</p>
+        </details>
+        <details class="game-card">
+          <summary>The Legend of Zelda: Oracle of Seasons (2001)</summary>
+          <p class="genre">Combat-Heavy Adventure</p>
+          <p><strong>If you liked:</strong> Death’s Door</p>
+          <p>Season-shifting rod changes terrain to solve quickfire puzzles.</p>
+          <p>Link rescues dancer Din and repairs the four seasonal spirits of Holodrum.</p>
+          <p>Developed alongside Ages; intended as part of a trilogy.</p>
+          <p>Swapping seasons feels like BOTW weather tricks but in micro form—ideal for short hops.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Land 2: 6 Golden Coins (1992)</summary>
+          <p class="genre">2-D Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Bros. Wonder</p>
+          <p>Open map lets you tackle themed zones in any order; levels average three minutes.</p>
+          <p>Mario reclaims his kingdom from first-time villain Wario by collecting six boss coins.</p>
+          <p>Debut of Wario; pushed the Game Boy sprite limit.</p>
+          <p>Suspend points mean you can clear a stage or two on a coffee break.</p>
+        </details>
+        <details class="game-card">
+          <summary>Wario Land 3 (2000)</summary>
+          <p class="genre">Puzzle-Platformer</p>
+          <p><strong>If you liked:</strong> Metroid Dread’s backtracking loops</p>
+          <p>Invincible Wario solves item-gated riddles in chunky stages.</p>
+          <p>A caged deity bribes Wario with treasure to piece together a ruined temple.</p>
+          <p>Introduced day–night cycle and golf mini-game.</p>
+          <p>Each loop adds shortcuts that make five-minute treasure runs addictive.</p>
         </details>
         <details class="game-card">
           <summary>Metroid II: Return of Samus (1991)</summary>
-          <p class="genre">Action-Adventure</p>
-          <p><strong>If you liked:</strong> Metroid Dread’s relentless hunt</p>
-          <p>Samus lands on SR388 to eradicate the Metroid species, delving deeper into caverns.</p>
-          <p>Story is minimal but sets up the events of Super Metroid.</p>
-          <p>Introduced new abilities and a save feature uncommon for Game Boy games.</p>
-          <p>Monochrome graphics are simple, yet the exploration loop still shines.</p>
+          <p class="genre">Exploration Action</p>
+          <p><strong>If you liked:</strong> Axiom Verge</p>
+          <p>Samus hunts 40 evolving Metroids through caverns built for handheld play.</p>
+          <p>The Galactic Federation orders the extermination of SR388’s Metroid species.</p>
+          <p>Created entirely at Nintendo R&D1 in Kyoto; foundation for Metroid Fusion.</p>
+          <p>Linear “Metroid count” tracker keeps objectives clear for bite-sized sessions.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby’s Dream Land 2 (1995)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> Kirby Star Allies</p>
+          <p>Copy abilities pair with three rideable animal friends for combo powers.</p>
+          <p>Kirby gathers Rainbow Drops to banish Dark Matter from Dream Land.</p>
+          <p>First appearance of Gooey and the animal trio.</p>
+          <p>Short, forgiving levels—easy to finish one during a bus ride.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby’s Dream Land (1992)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> Yoshi’s Crafted World</p>
+          <p>The very first Kirby: inhale, spit, or inflate to fly across five breezy stages.</p>
+          <p>Kirby retrieves Dream Land’s stolen food from King Dedede.</p>
+          <p>Created by 22-year-old Masahiro Sakurai; Kirby was white on the original box art.</p>
+          <p>Full run is under 30 minutes, yet every stage is an ideal five-minute snack.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon Trading Card Game (1998)</summary>
+          <p class="genre">Card-Battler RPG</p>
+          <p><strong>If you liked:</strong> Marvel Snap</p>
+          <p>Collect booster packs and duel AI opponents under classic TCG rules.</p>
+          <p>You, the new kid, aim to defeat the eight Club Masters and inherit the Legendary Cards.</p>
+          <p>Built by Hudson; taught a generation card rules before the internet.</p>
+          <p>A single duel lasts 5-10 minutes—perfect for quick strategic bursts.</p>
+        </details>
+        <details class="game-card">
+          <summary>Gargoyle’s Quest (1990)</summary>
+          <p class="genre">Action-RPG Platformer</p>
+          <p><strong>If you liked:</strong> Guacamelee! 2</p>
+          <p>Firebrand’s wall-climb and hover redefine classic platforming.</p>
+          <p>Demons overrun the Ghoul Realm—Firebrand must reclaim his homeland.</p>
+          <p>Spin-off of Capcom’s Ghosts ’n Goblins series; mixed RPG towns with action stages.</p>
+          <p>Checkpoints are frequent; each side-scroll area clocks ~6 minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Donkey Kong (1994)</summary>
+          <p class="genre">Puzzle-Platformer</p>
+          <p><strong>If you liked:</strong> Captain Toad: Treasure Tracker</p>
+          <p>Starts as the arcade four-screen set, then explodes into 97 key-unlock puzzles.</p>
+          <p>Mario pursues DK and Junior across cities, forests, and a desert.</p>
+          <p>Showcased Super Game Boy borders and stereo sound.</p>
+          <p>Every puzzle is self-contained and rarely tops three minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Golf GB (1999)</summary>
+          <p class="genre">Sports-RPG</p>
+          <p><strong>If you liked:</strong> Golf Story</p>
+          <p>Level-up your custom golfer in bite-size 18-hole tours.</p>
+          <p>Rookie golfer rises through four clubs to face Mario.</p>
+          <p>Camelot’s RPG mode later inspired Mario Golf: Advance Tour.</p>
+          <p>One 3-hole challenge is a relaxed five-minute detox.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Tennis GB (2001)</summary>
+          <p class="genre">Sports-RPG</p>
+          <p><strong>If you liked:</strong> Mario Tennis Aces</p>
+          <p>XP grind, gear shops, and quick best-of-3 matches.</p>
+          <p>Academy students rally their way to an exhibition with Mario &amp; Peach.</p>
+          <p>Link-cable trading unlocked extra characters on N64.</p>
+          <p>A full match is &lt;10 minutes; AI difficulty scales gently.</p>
+        </details>
+        <details class="game-card">
+          <summary>Tetris DX (1998)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Tetris Effect Connected</p>
+          <p>The definitive GB color version with quick-save high scores.</p>
+          <p>No plot—just endless line-clearing zen.</p>
+          <p>Added battery save and two new modes over 1989 original.</p>
+          <p>Marathon, 40-Line, or Ultra mode slide cleanly into any time gap.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario’s Picross (1995)</summary>
+          <p class="genre">Logic Puzzle</p>
+          <p><strong>If you liked:</strong> Picross S series</p>
+          <p>Pick-cross number clues to unveil 8-bit art.</p>
+          <p>Archaeologist Mario chips away stone murals; no narrative.</p>
+          <p>One of Nintendo’s earliest edutainment-puzzle ventures.</p>
+          <p>Puzzles start at 5×5 grids—solvable in two minutes on low stress.</p>
+        </details>
+        <details class="game-card">
+          <summary>Survival Kids (1999)</summary>
+          <p class="genre">Sandbox Survival-RPG</p>
+          <p><strong>If you liked:</strong> Don’t Starve Pocket Edition</p>
+          <p>Gather food, craft tools, and discover multiple endings on a deserted island.</p>
+          <p>A shipwrecked teen must signal rescue—or thrive alone.</p>
+          <p>Pre-dated Lost in Blue; just added to NSO in May 2025.</p>
+          <p>Day cycles are 8-10 minutes, letting you scavenge and save quickly.</p>
+        </details>
+        <details class="game-card">
+          <summary>Gradius: The Interstellar Assault (1991)</summary>
+          <p class="genre">Horizontal Shooter</p>
+          <p><strong>If you liked:</strong> Sky Force Reloaded</p>
+          <p>Power-up bar customisation meets branching stages.</p>
+          <p>Vic Viper thwarts a surprise invasion mid-warp.</p>
+          <p>Rare Konami GB shooter using parallax tricks.</p>
+          <p>One loop is 25 minutes; rewind makes tough spots approachable.</p>
+        </details>
+        <details class="game-card">
+          <summary>Castlevania Legends (1997)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> Bloodstained: Curse of the Moon</p>
+          <p>Sonia Belmont whips through six gothic stages with soul powers.</p>
+          <p>Ancestral Belmont beats Dracula centuries before Simon.</p>
+          <p>Final GB Castlevania; semi-canon today.</p>
+          <p>Save-assist smooths its classic-era difficulty; stages last ~7 minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Blaster Master: Enemy Below (2000)</summary>
+          <p class="genre">Hybrid Run-’n-Gun</p>
+          <p><strong>If you liked:</strong> Blaster Master Zero</p>
+          <p>Hop out of the tank for top-down mini-dungeons; perfect handheld scaling.</p>
+          <p>Jason hunts a new mutant menace beneath the earth.</p>
+          <p>Sunsoft recycled NES assets into a compact GB sequel.</p>
+          <p>Each area splits into bite-size screens you can clear in minutes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby Tilt ’n’ Tumble (2001, arriving July 2025)</summary>
+          <p class="genre">Motion Puzzle-Action</p>
+          <p><strong>If you liked:</strong> Super Monkey Ball</p>
+          <p>Roll Kirby by tilting your Switch; Joy-Con gyro emulates the cart’s accelerometer.</p>
+          <p>Kirby chases King Dedede’s stolen stars through marble-maze islands.</p>
+          <p>One of the first motion-sensor carts—now fully emulated.</p>
+          <p>Stages last 1-3 minutes and feel like fidget-toy bursts.</p>
         </details>
       </div>
     </section>
 
     <section id="gba">
-      <h2>Game Boy Advance Highlights</h2>
+      <h2>Game Boy Advance – Nintendo Classics</h2>
+      <p>(solo-friendly picks ranked #1 – 20; every title is playable in the GBA app today or has an official release date already on the calendar)</p>
       <div class="game-grid">
         <details class="game-card">
-          <summary>Metroid Fusion (2002)</summary>
-          <p class="genre">Action-Adventure</p>
-          <p><strong>If you liked:</strong> Metroid Dread’s guided storytelling</p>
-          <p>Samus battles a deadly parasite while receiving mission briefs from her ship’s AI.</p>
-          <p>The tense story drives exploration through a space station overrun with mutants.</p>
-          <p>Praised for tight pacing and atmospheric graphics on the GBA.</p>
-          <p>Plentiful save rooms keep the suspense from becoming punishing.</p>
+          <summary>The Legend of Zelda: The Minish Cap (2005)</summary>
+          <p class="genre">Top-down Adventure</p>
+          <p><strong>If you liked:</strong> Tears of the Kingdom’s shrine design</p>
+          <p>Shrink with the talking hat Ezlo, dive into anthill-sized dungeons, and fuse kinstones for secrets.</p>
+          <p>Link re-forges the sacred Picori Blade to uncurse Princess Zelda and stop sorcerer Vaati.</p>
+          <p>Capcom’s Flagship studio made this as the final piece of a Zelda handheld trilogy.</p>
+          <p>Most dungeons split into 3-room loops—ideal 10-minute puzzle bursts.</p>
         </details>
         <details class="game-card">
-          <summary>Advance Wars (2001)</summary>
-          <p class="genre">Turn-Based Strategy</p>
-          <p><strong>If you liked:</strong> Fire Emblem Engage’s bite-size battles</p>
-          <p>Command armies across grid-based maps, capturing cities to fund new units.</p>
-          <p>The lighthearted campaign introduces different commanders with unique powers.</p>
-          <p>Helped popularize strategy games on handhelds with simple, deep mechanics.</p>
-          <p>Difficulty scales smoothly, and turns can be undone thanks to rewind.</p>
+          <summary>Mario &amp; Luigi: Superstar Saga (2003)</summary>
+          <p class="genre">Comedy RPG</p>
+          <p><strong>If you liked:</strong> Paper Mario: Origami King</p>
+          <p>Bros. share one controller: A for Mario, B for Luigi—timed hits keep every turn interactive.</p>
+          <p>Beanbean Kingdom’s witch Cackletta steals Peach’s voice; the bros. chase her with rival Fawful ranting.</p>
+          <p>AlphaDream’s debut blended Mario platform timing with RPG menus.</p>
+          <p>Save blocks dot every screen, so you can play a single gag-filled encounter and bail.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid Fusion (2002)</summary>
+          <p class="genre">Exploration Action</p>
+          <p><strong>If you liked:</strong> Metroid Dread</p>
+          <p>Tense, linear planet SR388 lab crawl where the SA-X hunts you.</p>
+          <p>Infected by the X-parasite, Samus eliminates every last specimen to prevent galactic contagion.</p>
+          <p>First Metroid with in-game hints; spawned the “scary clone” trope.</p>
+          <p>Sectors are short; Navigation Rooms autosave—perfect chapter-length sessions.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid: Zero Mission (2004)</summary>
+          <p class="genre">Exploration Action</p>
+          <p><strong>If you liked:</strong> Axiom Verge</p>
+          <p>Full remake of the NES original plus a post-game Zero-Suit stealth chapter.</p>
+          <p>Samus raids planet Zebes, defeats Mother Brain, then escapes space-pirate captivity.</p>
+          <p>EAD rebuilt maps around modern mobility and added washable map icons.</p>
+          <p>You can clear one item loop in under 15 minutes thanks to quick rooms and suspend points.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby &amp; the Amazing Mirror (2004)</summary>
+          <p class="genre">Metroid-lite Platformer</p>
+          <p><strong>If you liked:</strong> Hollow Knight (map roaming)</p>
+          <p>Four-way maze where cell-phone lets you call clone Kirbys for help.</p>
+          <p>Dark Meta Knight shatters the mirror realm; Kirby reassembles it to purge the shadow.</p>
+          <p>HAL created the series’ first true open world; supports online co-op but solo works fine.</p>
+          <p>Portals link hubs, so a single route check can be a 10-minute task.</p>
+        </details>
+        <details class="game-card">
+          <summary>WarioWare, Inc.: Mega Microgame$! (2003)</summary>
+          <p class="genre">Micro-game Lightning-round</p>
+          <p><strong>If you liked:</strong> Rhythm Heaven</p>
+          <p>Over 200 five-second challenges—from nose-picking to boss fights.</p>
+          <p>Wario founds a get-rich-quick game studio in Diamond City.</p>
+          <p>Invented the micro-game genre on a one-month prototype sprint.</p>
+          <p>A full character stage lasts two minutes—perfect palette cleanser.</p>
+        </details>
+        <details class="game-card">
+          <summary>Wario Land 4 (2001)</summary>
+          <p class="genre">Treasure Platformer</p>
+          <p><strong>If you liked:</strong> Pizza Tower</p>
+          <p>Stage timer flips at the goal: sprint back to start with loot before doors slam.</p>
+          <p>Greedy Wario raids a golden pyramid for legendary riches.</p>
+          <p>Moved series from invincible puzzles to snappy, combo-chase action.</p>
+          <p>One loop is 6-8 minutes; rewind cushions the trickier escape runs.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Advance 4: Super Mario Bros. 3 (2003)</summary>
+          <p class="genre">2-D Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Bros. Wonder</p>
+          <p>NES classic plus e-Reader world with giant onions and cape feathers.</p>
+          <p>Bowser’s Koopalings seize seven kingdoms; Mario collects magic wands.</p>
+          <p>e-Reader levels—previously card-locked—are all unlocked on NSO.</p>
+          <p>Most stages under three minutes; perfect bite-size platforming.</p>
+        </details>
+        <details class="game-card">
+          <summary>Golden Sun (2001)</summary>
+          <p class="genre">Turn-based RPG</p>
+          <p><strong>If you liked:</strong> Octopath Traveler</p>
+          <p>Puzzle dungeons use Psynergy (telekinesis, frost, etc.) outside battle.</p>
+          <p>Adept Isaac stops rogue mages from lighting elemental lighthouses.</p>
+          <p>Camelot dropped Shining Force to craft this new IP with Mode7 overworld.</p>
+          <p>Roomy save-anywhere lets you clear one dungeon puzzle at a time.</p>
+        </details>
+        <details class="game-card">
+          <summary>Golden Sun: The Lost Age (2003)</summary>
+          <p class="genre">Turn-based RPG</p>
+          <p><strong>If you liked:</strong> Sea of Stars</p>
+          <p>Sequel flips viewpoint to the former antagonists.</p>
+          <p>Felix’s crew lights the remaining lighthouses to avert worldwide cataclysm.</p>
+          <p>First GBA cart to ship with 256-kB save for cross-file transfers.</p>
+          <p>Longer, but towns and puzzles are compartmentalised for 15-minute runs.</p>
+        </details>
+        <details class="game-card">
+          <summary>Fire Emblem: The Sacred Stones (2004)</summary>
+          <p class="genre">Tactics RPG</p>
+          <p><strong>If you liked:</strong> Triangle Strategy</p>
+          <p>Permadeath optional via NSO rewind; world map allows skirmish grinding.</p>
+          <p>Royal twins Eirika &amp; Ephraim repel demon king Fomortiis.</p>
+          <p>Standalone entry built on the Blazing Blade engine to ease Western newcomers.</p>
+          <p>One map ≈ 12 minutes on Easy; suspend save mid-turn anytime.</p>
+        </details>
+        <details class="game-card">
+          <summary>Fire Emblem (2003) (aka Blazing Blade)</summary>
+          <p class="genre">Tactics RPG</p>
+          <p><strong>If you liked:</strong> Advance Wars 1+2 Re-Boot</p>
+          <p>Tutorial acts as Lyn’s 10-chapter mini-arc before the main war.</p>
+          <p>Three lords—Lyn, Eliwood, Hector—unravel a black-fang conspiracy.</p>
+          <p>First English Fire Emblem, green-lighting the series’ global future.</p>
+          <p>Maps are brisk; modern tools soften classic permadeath tension.</p>
+        </details>
+        <details class="game-card">
+          <summary>Zelda: A Link to the Past &amp; Four Swords (2002)</summary>
+          <p class="genre">Top-down Adventure + Bonus Co-op</p>
+          <p><strong>If you liked:</strong> Tunic / Triforce Heroes</p>
+          <p>Full SNES masterpiece plus optional 2-4-player Four Swords side game.</p>
+          <p>Link crosses Light &amp; Dark Worlds to seal Ganon; Four Swords pits Links in competitive dungeons.</p>
+          <p>First portable co-op Zelda; Four Swords later ported to DSiWare anniversary.</p>
+          <p>ALttP dungeons divide cleanly into 5-room checkpoints—great stop-and-go.</p>
+        </details>
+        <details class="game-card">
+          <summary>Mario Kart: Super Circuit (2001)</summary>
+          <p class="genre">Kart Racer</p>
+          <p><strong>If you liked:</strong> Mario Kart 8 Deluxe offline</p>
+          <p>40 tracks (incl. all SNES courses) scaled for quick cups.</p>
+          <p>No narrative—just Mushroom Cup glory.</p>
+          <p>Intelligent Systems handled Mode7 scaling; handheld link play pioneer.</p>
+          <p>A five-race cup is 10–12 minutes; AI rubber-bands gently on 50 cc.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kuru Kuru Kururin (2001)</summary>
+          <p class="genre">Maze-Spinner Puzzle</p>
+          <p><strong>If you liked:</strong> Roundguard / mobile Rotato</p>
+          <p>Rotate a helicopter stick through pipe mazes without scraping walls.</p>
+          <p>Kururin rescues lost siblings scattered across worlds.</p>
+          <p>Nintendo &amp; Eighting designed it to teach analog precision to kids.</p>
+          <p>One course ≈ 45 seconds; perfect “just one more” reflex snack.</p>
+        </details>
+        <details class="game-card">
+          <summary>F-Zero Climax (2004)</summary>
+          <p class="genre">Futuristic Racer</p>
+          <p><strong>If you liked:</strong> FAST RMX</p>
+          <p>200 kph G-diffuser sprints plus in-game track editor.</p>
+          <p>Captain Falcon ends Dark Million’s crime wave in desert planet Sand Ocean.</p>
+          <p>Never exported until the 2024 NSO English patch.</p>
+          <p>A full GP cup is 8 minutes; rewind curbs the brutal curves.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon Mystery Dungeon: Red Rescue Team (2006)</summary>
+          <p class="genre">Roguelike RPG</p>
+          <p><strong>If you liked:</strong> Hades pattern loop</p>
+          <p>You awaken as a Pokémon and tackle randomised 99-floor dungeons.</p>
+          <p>Rescue teams stop meteors and a world-freezing legend Rayquaza.</p>
+          <p>Spun off Chunsoft’s Shiren engine; birthed a decade-long sub-series.</p>
+          <p>One mission is 5 floors ≈ 6 minutes; quick-save in any corridor.</p>
+        </details>
+        <details class="game-card">
+          <summary>Yoshi’s Island: Super Mario Advance 3 (2002)</summary>
+          <p class="genre">2-D Platformer</p>
+          <p><strong>If you liked:</strong> Yoshi’s Crafted World</p>
+          <p>Adds tilt-maze bonus games and extra levels on top of SNES classic.</p>
+          <p>Yoshi herd escorts Baby Mario past Baby Bowser’s castle.</p>
+          <p>Used GBA’s voice sample channel for cartoon squeals.</p>
+          <p>Stages average 4 minutes; 100-pt score chase optional.</p>
+        </details>
+        <details class="game-card">
+          <summary>Densetsu no Starfy 2 (2003)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> Kirby and the Forgotten Land (feel)</p>
+          <p>Starfy swims, spins, and teams with clam buddy to steal back heart pieces.</p>
+          <p>Ogura escapes sea jail; Starfy recovers the broken Sacred Treasures.</p>
+          <p>Series hit worldwide service only in 2024 NSO drop.</p>
+          <p>Levels are breezy 2–3 minutes—pure chill platforming.</p>
+        </details>
+        <details class="game-card">
+          <summary>F-Zero Maximum Velocity (2001)</summary>
+          <p class="genre">Futuristic Racer</p>
+          <p><strong>If you liked:</strong> Redout 2</p>
+          <p>Mode7-plus speed creates 300 kph handheld thrills.</p>
+          <p>Set 25 years after the original Grand Prix with new racers.</p>
+          <p>First GBA launch title outside Japan; no Captain Falcon cameo.</p>
+          <p>Beginner league cups clock 6 minutes; quick restart removes sting.</p>
         </details>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- expand SNES section with 20 classic entries
- add full Game Boy/Game Boy Color lineup
- replace GBA section with 20 ranked classics

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684eecbbf7588330b8e5fbfc0206da61