### PR TITLE
Update Switch catalog with new Genesis and GameCube picks

### DIFF
--- a/websites/switch-catalog/index.html
+++ b/websites/switch-catalog/index.html
@@ -17,6 +17,7 @@
       <a href="#gb">Game Boy</a>
       <a href="#gba">GBA</a>
       <a href="#genesis">Genesis</a>
+      <a href="#gamecube">GameCube</a>
     </nav>
   </header>
   <main>
@@ -954,25 +955,377 @@
     </section>
 
     <section id="genesis">
-      <h2>Sega Genesis Picks</h2>
+      <h2>Sega Genesis – Nintendo Switch Online</h2>
+      <p>(solo-friendly picks you can enjoy in 10- to 60-minute bursts; all 20 are playable today in the Genesis app or were officially added in the April 11 2025 drop)</p>
       <div class="game-grid">
         <details class="game-card">
           <summary>Sonic the Hedgehog 2 (1992)</summary>
-          <p class="genre">Platformer</p>
-          <p><strong>If you liked:</strong> Sonic Mania’s speedy stages</p>
-          <p>Sonic and Tails dash through colorful zones collecting rings to stop Dr. Robotnik.</p>
-          <p>The simple story pushes you from zone to zone until the final showdown.</p>
-          <p>Introduced the spin dash and became one of the best-selling Genesis games.</p>
-          <p>Fast physics remain exhilarating, and save states ease the later levels.</p>
+          <p class="genre">2-D Platformer</p>
+          <p><strong>If you liked:</strong> Super Mario Bros. Wonder speed runs</p>
+          <p>Blast loop-de-loops, grab rings, tag in Tails.</p>
+          <p>Sonic &amp; Tails stop Robotnik’s Death Egg.</p>
+          <p>First “Tails Tuesday” global launch; built on a six-month “crunch caravan.”</p>
+          <p>Single act ≈ 3 min; rewind erases spike-trap rage.</p>
+        </details>
+        <details class="game-card">
+          <summary>Streets of Rage 2 (1992)</summary>
+          <p class="genre">Beat-’em-up</p>
+          <p><strong>If you liked:</strong> TMNT: Shredder’s Revenge</p>
+          <p>Four vigilantes clean up a neon city with suplexes.</p>
+          <p>Syndicate king Mr. X kidnaps Adam; friends strike back.</p>
+          <p>‘92 Yamaha FM soundtrack became club-scene legend.</p>
+          <p>Each stage ≈ 7 min; Normal mode won’t punish newcomers.</p>
+        </details>
+        <details class="game-card">
+          <summary>Castlevania: Bloodlines (1994)</summary>
+          <p class="genre">Action-Platformer</p>
+          <p><strong>If you liked:</strong> Dead Cells gothic runs</p>
+          <p>Whip-swinging tour of WWI Europe with screen-filling bosses.</p>
+          <p>John Morris and Eric Lecarde pursue Dracula’s niece, Elizabeth.</p>
+          <p>Only Castlevania built purely for Genesis FM sound.</p>
+          <p>Six bite-size stages; suspend after any checkpoint.</p>
         </details>
         <details class="game-card">
           <summary>Gunstar Heroes (1993)</summary>
-          <p class="genre">Run-and-Gun</p>
-          <p><strong>If you liked:</strong> Cuphead’s intense boss fights</p>
-          <p>Take on swarms of enemies with mix-and-match weapons in explosive stages.</p>
-          <p>The loose plot is an excuse for nonstop action.</p>
-          <p>Treasure’s debut title pushed the Genesis hardware with flashy effects.</p>
-          <p>Two-player co-op and constant action keep the fun factor high.</p>
+          <p class="genre">Run-’n-Gun</p>
+          <p><strong>If you liked:</strong> Cuphead boss chaos</p>
+          <p>Stack two weapon types for 14 wild combos.</p>
+          <p>Sibling heroes race to stop Golden Silver’s re-awakening.</p>
+          <p>Treasure’s debut after ex-Konami staff left in rebellion.</p>
+          <p>Levels are 5-min rollercoasters; Easy mode softens bullet hell.</p>
+        </details>
+        <details class="game-card">
+          <summary>Phantasy Star IV (1995)</summary>
+          <p class="genre">JRPG</p>
+          <p><strong>If you liked:</strong> Sea of Stars</p>
+          <p>Sci-fi/fantasy quest with manga-panel cut-ins.</p>
+          <p>Hunters Chaz &amp; Alys uncover planet-eating Profound Darkness.</p>
+          <p>Saved the series after PS III backlash; 24-Mbit mega-cart.</p>
+          <p>Dungeons are short; quick-save anywhere makes 15-min sessions viable.</p>
+        </details>
+        <details class="game-card">
+          <summary>Shining Force (1992)</summary>
+          <p class="genre">Tactical RPG</p>
+          <p><strong>If you liked:</strong> Triangle Strategy (Easy)</p>
+          <p>Grid battles + town exploration and weapon shops.</p>
+          <p>The Shining Force fights Runefaust’s bid to revive Dark Dragon.</p>
+          <p>Camelot’s launch before its later Mario sports fame.</p>
+          <p>One map ≈ 10 min; rewind rescues fallen allies if permadeath scares you.</p>
+        </details>
+        <details class="game-card">
+          <summary>Ristar (1995)</summary>
+          <p class="genre">Stretch-Arm Platformer</p>
+          <p><strong>If you liked:</strong> Ori and the Will of the Wisps</p>
+          <p>Grab-and-head-butt everything with elastic arms.</p>
+          <p>Shooting Star Ristar frees constellation-ruled planets.</p>
+          <p>Sonic Team’s “mascot B-side” late in the Genesis lifecycle.</p>
+          <p>Worlds last 6 min; lavish parallax keeps it breezy.</p>
+        </details>
+        <details class="game-card">
+          <summary>Comix Zone (1995)</summary>
+          <p class="genre">Panel-Hopping Brawler</p>
+          <p><strong>If you liked:</strong> Hi-Fi Rush</p>
+          <p>Fight through comic panels you literally tear apart.</p>
+          <p>Cartoonist Sketch Turner battles his own villain, Mortus.</p>
+          <p>Built on Sega of America tech demo; rotoscoped sprites.</p>
+          <p>Chapters fit 7-min sprints; rewind masks its famous difficulty spikes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Golden Axe (1989)</summary>
+          <p class="genre">Hack-’n-Slash</p>
+          <p><strong>If you liked:</strong> Hades melee feel</p>
+          <p>Sword, axe, or magic dragon-ride across barbarian lands.</p>
+          <p>Trio seeks revenge on Death Adder for village slaughters.</p>
+          <p>AM1 ported the arcade and kept co-op intact.</p>
+          <p>Arcade mode clears in 25 min; each checkpoint autosaves.</p>
+        </details>
+        <details class="game-card">
+          <summary>Contra: Hard Corps (1994)</summary>
+          <p class="genre">Run-’n-Gun</p>
+          <p><strong>If you liked:</strong> Neon White twitch runs</p>
+          <p>Four heroes, branching paths, 14 endings.</p>
+          <p>Alien cell heists spark global meltdown; Corps fixes it.</p>
+          <p>First Contra without the Probotector swap in EU/US.</p>
+          <p>Brutal, but rewind trims grind; a route is &lt; 15 min.</p>
+        </details>
+        <details class="game-card">
+          <summary>ToeJam &amp; Earl in Panic on Funkotron (1993)</summary>
+          <p class="genre">Exploration Platformer</p>
+          <p><strong>If you liked:</strong> Slime Rancher chill collects</p>
+          <p>Tag alien earthlings with jars, explore funky forests.</p>
+          <p>Rap aliens round up Earth tourists loose on Funkotron.</p>
+          <p>Added in Nov 2024 NSO update after fan clamor.</p>
+          <p>Zones are calm 4-min collect-athons—zero stress.</p>
+        </details>
+        <details class="game-card">
+          <summary>Alien Soldier (1995)</summary>
+          <p class="genre">Boss-Rush Shooter</p>
+          <p><strong>If you liked:</strong> Cuphead expert mode</p>
+          <p>25 bosses, air dashes, twin-stick style aiming.</p>
+          <p>Gene-spliced Epsilon-Eagle rebels against Scarlet Desert army.</p>
+          <p>Treasure’s passion project; NTSC debut via Sega Channel—NSO revived it.</p>
+          <p>Supereasy mode + rewind makes each 90-sec boss bite-size.</p>
+        </details>
+        <details class="game-card">
+          <summary>M.U.S.H.A. (1990)</summary>
+          <p class="genre">Vertical Shmup</p>
+          <p><strong>If you liked:</strong> Ikaruga</p>
+          <p>Feudal-mech ship, killer FM soundtrack, chunky power-ups.</p>
+          <p>Terran pilots fend off rogue AI centered on asteroid base.</p>
+          <p>Compile’s cult classic once rare; NSO made it accessible.</p>
+          <p>One loop ≈ 25 min; stage select great for five-minute dogfights.</p>
+        </details>
+        <details class="game-card">
+          <summary>Dr. Robotnik’s Mean Bean Machine (1993)</summary>
+          <p class="genre">Puzzle</p>
+          <p><strong>If you liked:</strong> Puyo Puyo Tetris 2</p>
+          <p>Match blobs to bury rival bots under garbage beans.</p>
+          <p>Sonic’s nemesis kidnaps Mobians for a robotization plot.</p>
+          <p>Western reskin of Puyo Puyo; kicked off Sonic TV-tie-in era.</p>
+          <p>Single round 2–3 min—ideal cognitive coffee break.</p>
+        </details>
+        <details class="game-card">
+          <summary>Vectorman (1995)</summary>
+          <p class="genre">Run-’n-Gun Platformer</p>
+          <p><strong>If you liked:</strong> ReCore</p>
+          <p>Orbot hero morphs into drills, missiles, bombs.</p>
+          <p>Clear a toxic-fallout Earth from rogue robot WarHead.</p>
+          <p>BlueSky coded clay-style vector sprites to rival Donkey Kong CGI.</p>
+          <p>Levels average 4 min; frequent checkpoints soften spikes.</p>
+        </details>
+        <details class="game-card">
+          <summary>Dynamite Headdy (1994)</summary>
+          <p class="genre">Action Platformer</p>
+          <p><strong>If you liked:</strong> It Takes Two prop comedy</p>
+          <p>Detachable puppet head becomes hammers, vacuums, grapples.</p>
+          <p>Stagehand Headdy saves the puppet kingdom from Dark Demon.</p>
+          <p>Treasure flexed rainbow color cycles on base Genesis.</p>
+          <p>Bosses every 2 min; Easy mode unlockable via code.</p>
+        </details>
+        <details class="game-card">
+          <summary>Light Crusader (1995)</summary>
+          <p class="genre">Isometric Action-RPG</p>
+          <p><strong>If you liked:</strong> Tunic lite</p>
+          <p>Puzzles, sword-combat, and block-pushing in 3-D dungeon.</p>
+          <p>Sir David rescues townsfolk kidnapped for demon rites.</p>
+          <p>Treasure’s rare dive into RPG genre; hit NSO March 2022.</p>
+          <p>Floors save on exit; one puzzle room fits a five-minute stint.</p>
+        </details>
+        <details class="game-card">
+          <summary>Ecco the Dolphin (1992)</summary>
+          <p class="genre">Underwater Adventure</p>
+          <p><strong>If you liked:</strong> ABZÛ vibes</p>
+          <p>Sonar map, spin attacks, labyrinthine ocean caves.</p>
+          <p>Ecco seeks his pod abducted by alien storm.</p>
+          <p>Ed Annunziata’s eco fable spawned four sequels.</p>
+          <p>Levels are 6-min zen swims; rewind douses drowning anxiety.</p>
+        </details>
+        <details class="game-card">
+          <summary>ESWAT: City Under Siege (1990)</summary>
+          <p class="genre">Action Shooter</p>
+          <p><strong>If you liked:</strong> Broforce</p>
+          <p>Cops in power armor scale skyscrapers blasting cyborg gangs.</p>
+          <p>Rookie officer upgrades to cyber-suit to crush E.Y.E. cartel.</p>
+          <p>Added in April 2025 alongside Streets of Rage 1.</p>
+          <p>Missions last 4-5 min; armor mode feels like mini-Mega Man.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Fantasy Zone (1992)</summary>
+          <p class="genre">Horizontal Shmup</p>
+          <p><strong>If you liked:</strong> Graceful Explosion Machine</p>
+          <p>Cute-’em-up where you shop for weapon upgrades mid-stage.</p>
+          <p>Opa-Opa avenges papa’s death across eight rainbow planets.</p>
+          <p>Long-Japan-exclusive until NSO March 2022 drop.</p>
+          <p>Each planet ≈ 5 min; bright colors, low stress.</p>
+        </details>
+      </div>
+    </section>
+
+    <section id="gamecube">
+      <h2>Nintendo GameCube – Nintendo Classics</h2>
+      <p>(last stop on our emulator tour — here are 20 solo-friendly picks ordered with your “quick-burst, not-too-brutal” play style in mind)</p>
+      <p>#1–10 are confirmed launch or “coming soon” titles Nintendo has publicly listed for the GameCube app on Switch 2.</p>
+      <p>#11–20 are front-runner classics that haven’t been formally dated yet but are widely tipped by first-party press kits and partner teases. I’ve star-marked these as (✱ Speculative) so you can track what’s official versus “very likely next”.</p>
+      <div class="game-grid">
+        <details class="game-card">
+          <summary>The Legend of Zelda: The Wind Waker (2002)</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> TOTK’s open exploration</p>
+          <p>Sail a cel-shaded Great Sea, grappling islands for self-contained puzzle minidungeons.</p>
+          <p>Link and pirate Tetra chase Ganondorf to resurrect sunken Hyrule.</p>
+          <p>First fully orchestrated Zelda; Toon-style gamble paid off after SpaceWorld ’01 backlash.</p>
+          <p>Islands take 5–10 min each—perfect “one treasure chart” sessions.</p>
+        </details>
+        <details class="game-card">
+          <summary>Luigi’s Mansion (2001)</summary>
+          <p class="genre">Puzzle-Horror-Lite</p>
+          <p><strong>If you liked:</strong> Luigi’s Mansion 3</p>
+          <p>Vacuum ghosts in an ever-looping mansion stuffed with 90-second rooms.</p>
+          <p>Luigi wins a “free” mansion—only to find Mario trapped inside by King Boo.</p>
+          <p>Built to demo GameCube lighting; launched Day 1 in place of a Mario game.</p>
+          <p>Each corridor is a snack-size puzzle; save after every portrait ghost.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Sunshine (2002)</summary>
+          <p class="genre">3-D Platformer</p>
+          <p><strong>If you liked:</strong> Mario Odyssey</p>
+          <p>FLUDD jet-pack turns jumps into hover puzzles and water-gun clean-ups.</p>
+          <p>Wrongly accused of graffiti, Mario scrubs Isle Delfino and unmasks Shadow Mario.</p>
+          <p>EAD Tokyo’s first big Mario; pushed analog triggers for pressure sprays.</p>
+          <p>Most shines &lt;6 min; you can bail after any blue-coin or red-coin sprint.</p>
+        </details>
+        <details class="game-card">
+          <summary>Fire Emblem: Path of Radiance (2005)</summary>
+          <p class="genre">Tactical RPG</p>
+          <p><strong>If you liked:</strong> Triangle Strategy</p>
+          <p>Grid battles with permadeath toggle and between-fight prep tents.</p>
+          <p>Mercenary Ike leads Crimea’s liberation and discovers the branded Laguz.</p>
+          <p>Intelligent Systems’ first fully 3-D FE; voice cut-scenes debuted here.</p>
+          <p>One map ≈12 min on Normal; suspend mid-turn anytime in NSO.</p>
+        </details>
+        <details class="game-card">
+          <summary>F-Zero GX (2003)</summary>
+          <p class="genre">Futuristic Racer</p>
+          <p><strong>If you liked:</strong> FAST RMX</p>
+          <p>Boost at 2000 kph across corkscrew tracks; Story Mode adds bite-size challenges.</p>
+          <p>Captain Falcon stops Black Shadow in nine comic-book chapters.</p>
+          <p>Co-developed with Sega’s Amusement Vision on the AX arcade board.</p>
+          <p>Each GP cup &lt;10 min; NSO rewind softens famously punishing corners.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon XD: Gale of Darkness (2005)</summary>
+          <p class="genre">RPG / Monster-Battler</p>
+          <p><strong>If you liked:</strong> Pokémon Legends: Arceus</p>
+          <p>Steal (“Snag”) corrupted Shadow Pokémon and purify them via battles.</p>
+          <p>Hero Michael thwarts Cipher’s Shadow Lugia doomsday plot.</p>
+          <p>Genius Sonority iterated on Colosseum’s engine in just 18 months.</p>
+          <p>Dungeons save every door; a single Snag run fits a coffee break.</p>
+        </details>
+        <details class="game-card">
+          <summary>Chibi-Robo! (2005)</summary>
+          <p class="genre">Life-Sim Platformer</p>
+          <p><strong>If you liked:</strong> Tinykin</p>
+          <p>Clean a toy-box house earning Happy Points while battery-managing.</p>
+          <p>Six-inch robot mends the Sanderson family’s finances and relationships.</p>
+          <p>Began life as a point-and-click; Miyamoto steered it to platform-sim blend.</p>
+          <p>Errand loops last 4–6 min—ideal “one chore” play sessions.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pokémon Colosseum (2004)</summary>
+          <p class="genre">RPG / Stadium-Battler</p>
+          <p><strong>If you liked:</strong> Temtem (linear RPG)</p>
+          <p>Steal Shadow Pokémon from crooks across Mad Max-style Orre.</p>
+          <p>Ex-villain Wes dismantles Team Snagem’s snag-machine scheme.</p>
+          <p>First 3-D story-driven Pokémon on console; reused Stadium models.</p>
+          <p>Colosseum bouts auto-save; one Cipher lab wing ≈7 min.</p>
+        </details>
+        <details class="game-card">
+          <summary>SoulCalibur II (2002)</summary>
+          <p class="genre">Weapon Fighter</p>
+          <p><strong>If you liked:</strong> Street Fighter 6 World Tour</p>
+          <p>Eight-hour weapon master mode plays like a mini-RPG.</p>
+          <p>Link guest-stars to reclaim the evil Soul Edge before it corrupts reality.</p>
+          <p>Namco added console-exclusive fighters (Link, Heihachi, Spawn).</p>
+          <p>Most missions last 90 sec; generous difficulty options for newcomers.</p>
+        </details>
+        <details class="game-card">
+          <summary>Super Mario Strikers (2005)</summary>
+          <p class="genre">Arcade Sports</p>
+          <p><strong>If you liked:</strong> Mario Strikers: Battle League</p>
+          <p>Five-on-five soccer with shell-shoot power-ups and Mega Strikes.</p>
+          <p>Mario captains Mushroom Kingdom cups against Bowser’s field.</p>
+          <p>Next Level Games’ debut for Nintendo before Luigi’s Mansion sequels.</p>
+          <p>One cup ≈12 min; offline season AI scales gently.</p>
+        </details>
+        <details class="game-card">
+          <summary>Metroid Prime (2002) ✱</summary>
+          <p class="genre">First-Person Adventure</p>
+          <p><strong>If you liked:</strong> Metroid Prime Remastered</p>
+          <p>Scan-visor, lock-on shooting, and environmental storytelling meld seamlessly.</p>
+          <p>Samus hunts Phazon corruption on planet Tallon IV.</p>
+          <p>Retro Studios fused FPS with classic Metroid design.</p>
+          <p>Each save room &lt;10 min away; suspend anywhere via NSO.</p>
+        </details>
+        <details class="game-card">
+          <summary>Pikmin (2001) ✱</summary>
+          <p class="genre">RTS-Puzzle</p>
+          <p><strong>If you liked:</strong> Tinykin</p>
+          <p>Command 100 carrot critters to haul parts under daylight timer.</p>
+          <p>Captain Olimar rebuilds his ship before 30 days pass.</p>
+          <p>EAD’s AI showcase inspired by garden walks.</p>
+          <p>One in-game day = 13 real minutes—built for burst play.</p>
+        </details>
+        <details class="game-card">
+          <summary>Paper Mario: The Thousand-Year Door (2004) ✱</summary>
+          <p class="genre">Turn-Based RPG</p>
+          <p><strong>If you liked:</strong> Bug Fables</p>
+          <p>Timing-button attacks and stage-play humor.</p>
+          <p>Mario collects Crystal Stars to stop the Shadow Queen.</p>
+          <p>Intelligent Systems polished the pop-up style from N64 entry.</p>
+          <p>Chapters save every room; battles finish in ~2 min.</p>
+        </details>
+        <details class="game-card">
+          <summary>Kirby Air Ride (2003) ✱</summary>
+          <p class="genre">Racing / Party</p>
+          <p><strong>If you liked:</strong> Fall Guys chaos laps</p>
+          <p>One-button “charge to brake” drifting across City Trial playground.</p>
+          <p>Kirby preps for a random stadium finale by hunting power-ups.</p>
+          <p>Sakurai’s last HAL game before Smash Brawl stint.</p>
+          <p>City Trial day cycle is 7 min—great quick burst.</p>
+        </details>
+        <details class="game-card">
+          <summary>Donkey Kong Jungle Beat (2004) ✱</summary>
+          <p class="genre">Rhythm-Platformer</p>
+          <p><strong>If you liked:</strong> Rhythm Heaven Fever reflexes</p>
+          <p>Clap/crest combos (mapped to triggers) rack up banana scores.</p>
+          <p>DK dethrones rival kings across 40 kingdoms.</p>
+          <p>Tokyo EAD prototyped Wii motion here, later birthing Mario Galaxy gravity.</p>
+          <p>A kingdom clears in 5 min; medals provide optional depth.</p>
+        </details>
+        <details class="game-card">
+          <summary>Star Fox Adventures (2002) ✱</summary>
+          <p class="genre">Action-Adventure</p>
+          <p><strong>If you liked:</strong> Kena: Bridge of Spirits</p>
+          <p>Zelda-style staff combat on Dinosaur Planet, plus on-rails sorties.</p>
+          <p>Fox saves Krystal and repairs the planet’s SpellStones.</p>
+          <p>Rare’s last Nintendo release before Microsoft buyout.</p>
+          <p>Quests hub-and-spoke; each puzzle sequence 6–8 min.</p>
+        </details>
+        <details class="game-card">
+          <summary>Animal Crossing (2003) ✱</summary>
+          <p class="genre">Life Sim</p>
+          <p><strong>If you liked:</strong> Animal Crossing: New Horizons</p>
+          <p>Real-time town chores, fossils, letters, NES games inside.</p>
+          <p>New human villager pays off Tom Nook’s home loan.</p>
+          <p>Enhanced port of N64’s Dōbutsu no Mori.</p>
+          <p>Daily play loops 10 min; perfect wind-down.</p>
+        </details>
+        <details class="game-card">
+          <summary>Wario World (2003) ✱</summary>
+          <p class="genre">3-D Beat-’em-Up</p>
+          <p><strong>If you liked:</strong> Bayonetta Origins puzzles</p>
+          <p>Greedy shoulder-charges meet treasure-room mini-levels.</p>
+          <p>Wario ransoms his own castle from evil Jewel.</p>
+          <p>Treasure’s only 3-D platformer; reused Ikaruga engine tricks.</p>
+          <p>Each world hub has 2-min sub-levels ideal for bite-size loot grabs.</p>
+        </details>
+        <details class="game-card">
+          <summary>Tales of Symphonia (2003) ✱</summary>
+          <p class="genre">Action JRPG</p>
+          <p><strong>If you liked:</strong> Ys VIII party brawls</p>
+          <p>Real-time “Linear Motion” combat on 3-D planes.</p>
+          <p>Chosen one Lloyd restores mana to two linked worlds.</p>
+          <p>Namco’s breakout Western JRPG hit; spawned multi-plat remasters.</p>
+          <p>Save at every field map; skits add story in 30-sec bursts.</p>
+        </details>
+        <details class="game-card">
+          <summary>Skies of Arcadia Legends (2003) ✱</summary>
+          <p class="genre">Airship RPG</p>
+          <p><strong>If you liked:</strong> Sea of Stars sky-faring</p>
+          <p>Explore floating islands in turn-based ship duels.</p>
+          <p>Blue Rogue Vyse thwarts Valuan Empire’s Gigas super-weapons.</p>
+          <p>Sega upgraded Dreamcast original with extra discoveries.</p>
+          <p>Each island dungeon splits into 5-min corridors; save on your deck any time.</p>
         </details>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add GameCube anchor to the site nav
- expand the Sega Genesis section with 20 detailed game cards
- add a new Nintendo GameCube section with launch and speculative titles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684efdaa5a0483308e9bafa87c4b2ca8